### PR TITLE
New Logic Additions

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -2261,14 +2261,19 @@ public class Main {
             else if (region == 0x15) {
 				// New MINOR GLITCHES Logic for Inside 2nd Hill.
 				// You can skip needing Boots if you have Red Overalls by breaking the blocks in a specific way, and then doing a walljump after obtaining this check.
+				// This can only be in logic on MINOR GLITCHES if it specifically contains the Red Key.
+				// If it's not the Red Key, it must be MERCILESS instead due to requiring a single tile walljump.
                 return inventory.contains(Items.GARLIC) && canLift(inventory)
-                        && (canSwim(inventory) || ((difficulty >= Difficulty.HARD && inventory.contains(Items.JUMP_BOOTS)) || (difficulty >= Difficulty.S_HARD && canSuperGP(inventory)));
+                        && (canSwim(inventory) 
+							|| ((difficulty >= Difficulty.HARD && inventory.contains(Items.JUMP_BOOTS)) 
+							|| (difficulty >= Difficulty.S_HARD && canSuperGP(inventory) && (keyColor == 1 || difficulty >= Difficulty.MERCILESS)));
             }
             else if (region == 0x16) {
-				// New MINOR GLITCHES Logic for Inside 4th Hill.
+				// New MERCILESS Logic for Inside 4th Hill.
 				// You can skip needing Boots if you have Red Overalls by breaking the blocks in a specific way, and then doing a reverse walljump after obtaining this check.
+				// The required 
                 return inventory.contains(Items.GARLIC) 
-						&& (canSwim(inventory) || (difficulty >= Difficulty.S_HARD && (inventory.contains(Items.JUMP_BOOTS) || canSuperGP(inventory))));
+						&& (canSwim(inventory) || (difficulty >= Difficulty.MERCILESS && (inventory.contains(Items.JUMP_BOOTS) || canSuperGP(inventory))));
             }
             else if (region == 0x17) {
 		/*
@@ -3211,7 +3216,7 @@ public class Main {
                 return ((inventory.contains(Items.BLUE_KEY_CARD) && inventory.contains(Items.RED_KEY_CARD) && canLift(inventory))
 					&& (inventory.contains(Items.SPIKED_HELMET) || (difficulty >= Difficulty.HARD && inventory.contains(Items.JUMP_BOOTS))))
 						|| (difficulty >= Difficulty.MERCILESS && inventory.contains(Items.WARP_REMOTE)
-							&& canSuperLift(inventory) && inventory.contains(Items.JUMP_BOOTS));
+							&& canSuperGP(inventory) && canSuperLift(inventory) && inventory.contains(Items.JUMP_BOOTS));
             }
             else if (region == 0x6) {
 		/* 
@@ -3239,7 +3244,7 @@ public class Main {
 		*/ 
                 return (inventory.contains(Items.BLUE_KEY_CARD) && inventory.contains(Items.RED_KEY_CARD) && canLift(inventory))
 			|| (difficulty >= Difficulty.MERCILESS && inventory.contains(Items.WARP_REMOTE)
-				&& canSuperLift(inventory) && inventory.contains(Items.JUMP_BOOTS));
+				&& canSuperGP(inventory) && canSuperLift(inventory) && inventory.contains(Items.JUMP_BOOTS));
             }
             else if (region == 0x18) {
 		if (location == 2) {

--- a/src/Main.java
+++ b/src/Main.java
@@ -2273,7 +2273,7 @@ public class Main {
 				// You can skip needing Boots if you have Red Overalls by breaking the blocks in a specific way, and then doing a reverse walljump after obtaining this check.
 				// The required 
                 return inventory.contains(Items.GARLIC) 
-						&& (canSwim(inventory) || (difficulty >= Difficulty.MERCILESS && (inventory.contains(Items.JUMP_BOOTS) || canSuperGP(inventory))));
+						&& (canSwim(inventory) || ((difficulty >= Difficulty.S_HARD && (inventory.contains(Items.JUMP_BOOTS))) || (difficulty >= Difficulty.MERCILESS && canSuperGP(inventory))));
             }
             else if (region == 0x17) {
 		/*

--- a/src/Main.java
+++ b/src/Main.java
@@ -2535,7 +2535,11 @@ public class Main {
                     return canSwim(inventory);
                 }
                 else if (location == 3) {
-                    return canSuperSwim(inventory);
+					// HARD logic for Main Area - Underwater Right: Outswim the current by Holding up+right and 
+					// pressing the dash button in a specific rhythm. You'll gain a bit of headway each time you keep rhythm.
+					// The fish will only hit you once at worst if executed right, and you can recover as long as you keep your inputs precise.
+                    return canSuperSwim(inventory)
+						|| (difficulty >= Difficulty.HARD && canSwim(inventory));
                 }
             }
             else if (region == 0x7) {

--- a/src/Main.java
+++ b/src/Main.java
@@ -2005,7 +2005,7 @@ public class Main {
         }
         else if (location.equals("E6R")) {
             // can manip pneumo to get past the fire
-			      // In addition, you can damage boost using the 2nd Paragoom to get through and reach this chest without needing Overalls.
+			// In addition, you can damage boost using the 2nd Paragoom to get through and reach this chest without needing Overalls.
             return canAccess("E6", inventory)
                     && (difficulty >= Difficulty.HARD || inventory.contains(Items.FIRE_EXTINGUISHER))
                     && canLift(inventory)
@@ -2126,10 +2126,15 @@ public class Main {
         else if (level.equals("N2")) {
             if (region == 0x1) {
                 if (location == 2) {
-                    return canSuperGP(inventory) && inventory.contains(Items.SPIKED_HELMET);
+					// Main Area - Behind Wall Right of Start is obtainable without the Helmet or Red Overalls.
+					// This is done by ladder scrolling at the ladder closest to the snake pot and navigating the terrain.
+					// A walljump is also required if you don't have Boots, but this won't check for Boots as MINOR GLITCHES is lower than MERCILESS on the difficulty scale.
+                    return (canSuperGP(inventory) && inventory.contains(Items.SPIKED_HELMET)) || difficulty >= Difficulty.MERCILESS;
                 }
                 else if (location == 0) {
-                    return !daytime || inventory.contains(Items.GARLIC);
+					// Main Area - Behind Wall Right of Start is obtainable without Garlic.
+					// This is done by ladder scrolling at the ladder closest to the snake pot and navigating the terrain.
+                    return !daytime || inventory.contains(Items.GARLIC) || difficulty >= Difficulty.MERCILESS;
                 }
                 else {
                     return true;
@@ -2419,7 +2424,7 @@ public class Main {
                     return ((difficulty >= Difficulty.S_HARD && canGP(inventory)) || inventory.contains(Items.SPIKED_HELMET)) && canLift(inventory);
                 }
                 else if (location == 2) {
-                    // Day Ruins Basement can be obtainable in MERCILESS without Overalls by Ladder Scrolling.
+					// Day Ruins Basement can be obtainable in MERCILESS without Overalls by Ladder Scrolling.
                     return canGP(inventory) || difficulty >= Difficulty.MERCILESS;
                 }
                 else {

--- a/src/Main.java
+++ b/src/Main.java
@@ -2262,11 +2262,10 @@ public class Main {
 				// New MINOR GLITCHES Logic for Inside 2nd Hill.
 				// You can skip needing Boots if you have Red Overalls by breaking the blocks in a specific way, and then doing a walljump after obtaining this check.
 				// This can only be in logic on MINOR GLITCHES if it specifically contains the Red Key.
-				// If it's not the Red Key, it must be MERCILESS instead due to requiring a single tile walljump.
                 return inventory.contains(Items.GARLIC) && canLift(inventory)
                         && (canSwim(inventory) 
 							|| ((difficulty >= Difficulty.HARD && inventory.contains(Items.JUMP_BOOTS)) 
-							|| (difficulty >= Difficulty.S_HARD && canSuperGP(inventory) && (keyColor == 1 || difficulty >= Difficulty.MERCILESS)));
+							|| (difficulty >= Difficulty.S_HARD && canSuperGP(inventory)));
             }
             else if (region == 0x16) {
 				// New MERCILESS Logic for Inside 4th Hill.

--- a/src/Main.java
+++ b/src/Main.java
@@ -2419,7 +2419,8 @@ public class Main {
                     return ((difficulty >= Difficulty.S_HARD && canGP(inventory)) || inventory.contains(Items.SPIKED_HELMET)) && canLift(inventory);
                 }
                 else if (location == 2) {
-                    return canGP(inventory);
+                    // Day Ruins Basement can be obtainable in MERCILESS without Overalls by Ladder Scrolling.
+                    return canGP(inventory) || difficulty >= Difficulty.MERCILESS;
                 }
                 else {
                     return true;

--- a/src/Main.java
+++ b/src/Main.java
@@ -2604,24 +2604,26 @@ public class Main {
                     return true;
                 }
                 else {
-		/*
-		* This was not originally checking for Boots, which is required for HARD logic. I fixed this issue.
-		* I also added a MINOR GLITCHES alternative for this check. 
-		* Break a small alcove in the right wall 1 block up, and leave the bottom left block able to be jumped on. 
-		* Then use a high walljump to escape out of the pit. 
-		* This MINOR GLITCHES alternative Skips needing the Helmet and Glove when compared to HARD Logic.
-		*/
-                    return canSuperGP(inventory)
-                        && (inventory.contains(Items.SPIKED_HELMET)
-                            || (difficulty >= Difficulty.HARD && canLift(inventory) && inventory.contains(Items.JUMP_BOOTS))
-				|| (difficulty >= Difficulty.S_HARD && inventory.contains(Items.JUMP_BOOTS)));
+				/*
+				* This was not originally checking for Boots, which is required for HARD logic. I fixed this issue.
+				* I also added a MINOR GLITCHES alternative for this check. 
+				* Break a small alcove in the right wall 1 block up, and leave the bottom left block able to be jumped on. 
+				* Then use a high walljump to escape out of the pit. 
+				* This MINOR GLITCHES alternative Skips needing the Helmet and Glove when compared to HARD Logic.
+				* Additional HARD Logic to skip needing Red Overalls involves going down the ladder and breaking the edge blocks from below.
+				*/
+                    return (canSuperGP(inventory)
+						&& (inventory.contains(Items.SPIKED_HELMET)
+							|| (difficulty >= Difficulty.HARD && canLift(inventory) && inventory.contains(Items.JUMP_BOOTS))
+								|| (difficulty >= Difficulty.S_HARD && inventory.contains(Items.JUMP_BOOTS))))
+						|| (difficulty >= Difficulty.HARD && canGP(inventory) && inventory.contains(Items.SPIKED_HELMET));
                 }
             }
             else if (region == 0x16) {
-		/*
-		* Added MERCILESS logic for this check, which is Switch Puzzle Side Room 1 - Upper Right.
-		* If you use Ladder Scrolling to reach the region, only a regular glove is needed to get this check.
-		*/
+			/*
+			* Added MERCILESS logic for this check, which is Switch Puzzle Side Room 1 - Upper Right.
+			* If you use Ladder Scrolling to reach the region, only a regular glove is needed to get this check.
+			*/
                 return canSuperLift(inventory)
 					|| (difficulty >= Difficulty.MERCILESS && canLift(inventory));
             }
@@ -2634,18 +2636,18 @@ public class Main {
                 }
             }
             else if (region == 0x19) {
-		/*
-		* Added MINOR GLITCHES logic for this check, which is Zombie Room - Below Third Platform.
-		* With a Reverse Walljump, it's possible to obtain this check without either the Helmet or Boots.
-		*/
+			/*
+			* Added MINOR GLITCHES logic for this check, which is Zombie Room - Below Third Platform.
+			* With a Reverse Walljump, it's possible to obtain this check without either the Helmet or Boots.
+			*/
                 return inventory.contains(Items.SPIKED_HELMET) || inventory.contains(Items.JUMP_BOOTS)
 			        || difficulty >= Difficulty.S_HARD;
             }
             else if (region == 0x1c) {
-		/*
-		* Added MERCILESS logic for this check, which is Switch Puzzle Side Room 2 - Upper Right.
-		* If you use Ladder Scrolling to reach the region, only the Red Overalls are needed to get this check.
-		*/
+			/*
+			* Added MERCILESS logic for this check, which is Switch Puzzle Side Room 2 - Upper Right.
+			* If you use Ladder Scrolling to reach the region, only the Red Overalls are needed to get this check.
+			*/
                 return canSuperGP(inventory)
 			&& (canSuperLift(inventory) || difficulty >= Difficulty.MERCILESS);
             }

--- a/src/Main.java
+++ b/src/Main.java
@@ -2126,7 +2126,7 @@ public class Main {
         else if (level.equals("N2")) {
             if (region == 0x1) {
                 if (location == 2) {
-					// Main Area - Behind Wall Right of Start is obtainable without the Helmet or Red Overalls.
+					// Main Area - Excavate Lower Right is obtainable without the Helmet or Red Overalls.
 					// This is done by ladder scrolling at the ladder closest to the snake pot and navigating the terrain.
 					// A walljump is also required if you don't have Boots, but this won't check for Boots as MINOR GLITCHES is lower than MERCILESS on the difficulty scale.
                     return (canSuperGP(inventory) && inventory.contains(Items.SPIKED_HELMET)) || difficulty >= Difficulty.MERCILESS;

--- a/src/Main.java
+++ b/src/Main.java
@@ -36,7 +36,7 @@ public class Main {
 
     private static GUI gui;
 
-    private static final String VERSION = "v0.12.0-RC3";
+    private static final String VERSION = "v0.12.0-RC4";
 
     public static void main(String[] args) {
         SwingUtilities.invokeLater(new Runnable() {
@@ -1592,14 +1592,14 @@ public class Main {
             return canAccess("W2", inventory);
         }
         else if (location.equals("W2R")) {
+            /*
+             * The MINOR GLITCHES execution added involves performing a big dashjump wallclip from the deactivated Trolley.
+             * Then do a midair enemy bounce to reach the platforms leading to the Golf.
+             * Finally, navigate rightwards while avoiding any other hazards on the way to reach the Red Chest.
+             */
             return canAccess("W2", inventory)
-			/*
-			* The MINOR GLITCHES execution added involves performing a big dashjump wallclip from the deactivated Trolley.
-			* Then do a midair enemy bounce to reach the platforms leading to the Golf.
-			* Finally, navigate rightwards while avoiding any other hazards on the way to reach the Red Chest.
-			*/
-                    && inventory.contains(Items.WHEELS)
-			|| (difficulty >= Difficulty.S_HARD && canLift(inventory) && inventory.contains(Items.JUMP_BOOTS));
+                && (inventory.contains(Items.WHEELS)
+			        || (difficulty >= Difficulty.S_HARD && canLift(inventory) && inventory.contains(Items.JUMP_BOOTS)));
         }
         else if (location.equals("W2G")) {
 			/*
@@ -1610,10 +1610,10 @@ public class Main {
 			* The same enemy bounce from HARD can then be used to reach the Golf that leads to the chest.
 			*/
             return canAccess("W2", inventory)
-                    && (inventory.contains(Items.WHEELS) && inventory.contains(Items.FLUTE))
-			|| (difficulty >= Difficulty.HARD && inventory.contains(Items.WHEELS) && inventory.contains(Items.JUMP_BOOTS) && canLift(inventory))
-			|| (difficulty >= Difficulty.S_HARD && inventory.contains(Items.JUMP_BOOTS) && canLift(inventory))
-                        || (difficulty >= Difficulty.MERCILESS && inventory.contains (Items.WHEELS) && inventory.contains(Items.JUMP_BOOTS));
+                && ((inventory.contains(Items.WHEELS) && inventory.contains(Items.FLUTE))
+			    || (difficulty >= Difficulty.HARD && inventory.contains(Items.WHEELS) && inventory.contains(Items.JUMP_BOOTS) && canLift(inventory))
+			    || (difficulty >= Difficulty.S_HARD && inventory.contains(Items.JUMP_BOOTS) && canLift(inventory))
+                || (difficulty >= Difficulty.MERCILESS && inventory.contains(Items.WHEELS) && inventory.contains(Items.JUMP_BOOTS)));
         }
         else if (location.equals("W2B")) {
             return canAccess("W2", inventory)
@@ -1657,8 +1657,8 @@ public class Main {
 			* This execution skips the need for the Air Pump.
 			*/
             return canAccess("W3", inventory)
-        		&& (inventory.contains(Items.PUMP) && canSwim(inventory))
-				|| (difficulty >= Difficulty.MERCILESS && canGP(inventory) && canLift(inventory) && inventory.contains(Items.JUMP_BOOTS));
+        		&& ((inventory.contains(Items.PUMP) && canSwim(inventory))
+				|| (difficulty >= Difficulty.MERCILESS && canGP(inventory) && canLift(inventory) && inventory.contains(Items.JUMP_BOOTS)));
         }
         else if (location.equals("W4S")) {
             return canAccess("W4", inventory);
@@ -1705,9 +1705,11 @@ public class Main {
                     && (difficulty > Difficulty.EASY || inventory.contains(Items.JUMP_BOOTS));
         }
         else if (location.equals("W5B")) {
+			// New HARD Logic for W5 Blue Chest: Dismount from the ladder while the Donuteer prepares to throw its Donut to the right.
+			// Timed properly, you can get up the ledge to eat the donut and break the donut blocks without needing a Glove.
             return canAccess("W5", inventory)
                     && canSwim(inventory)
-                    && canLift(inventory)
+                    && (difficulty >= Difficulty.HARD || canLift(inventory))
                     && (difficulty > Difficulty.EASY || inventory.contains(Items.JUMP_BOOTS));
         }
         else if (location.equals("W6S")) {
@@ -1872,9 +1874,9 @@ public class Main {
 			* The soft reset can occur either immediately before entering the stage or after a suspend save.
 			*/
             return canAccess("S6", inventory)
-		&& inventory.contains(Items.JUMP_BOOTS)
-                	&& ((inventory.contains(Items.GONG) && inventory.contains(Items.SCISSORS) && canSuperGP(inventory) && canLift(inventory))
-			|| (dayOnly && difficulty >= Difficulty.MERCILESS));
+		        && inventory.contains(Items.JUMP_BOOTS)
+                && ((inventory.contains(Items.GONG) && inventory.contains(Items.SCISSORS) && canSuperGP(inventory) && canLift(inventory))
+			        || (dayOnly && difficulty >= Difficulty.MERCILESS));
         }
         else if (location.equals("E1S")) {
             return canAccess("E1", inventory);
@@ -1888,7 +1890,7 @@ public class Main {
 				*/
                     && inventory.contains(Items.STONE_FOOT)
                     && (canGP(inventory) 
-				|| (inventory.contains(Items.JUMP_BOOTS) && (canSuperSwim(inventory) || (difficulty >= Difficulty.HARD && canSwim(inventory)))));
+				        || (inventory.contains(Items.JUMP_BOOTS) && (canSuperSwim(inventory) || (difficulty >= Difficulty.HARD && canSwim(inventory)))));
         }
         else if (location.equals("E1G")) {
 		// Added MINOR GLITCHES execution for this chest. Perform a walljump to reach the pipe that leads to Jamano.
@@ -1905,8 +1907,8 @@ public class Main {
 			* This will damage boost you and allow you to get enough height to reach the Blue Chest.
 			*/
             return canAccess("E1", inventory)
-                && ((inventory.contains(Items.DETONATOR))
-			|| (difficulty >= Difficulty.MERCILESS && canLift(inventory) && inventory.contains(Items.JUMP_BOOTS) && inventory.contains(Items.SPIKED_HELMET)));
+                && (inventory.contains(Items.DETONATOR)
+			        || (difficulty >= Difficulty.MERCILESS && canLift(inventory) && inventory.contains(Items.JUMP_BOOTS) && inventory.contains(Items.SPIKED_HELMET)));
         }
         else if (location.equals("E2S")) {
             return canAccess("E2", inventory);
@@ -1931,8 +1933,8 @@ public class Main {
 				* Finally, jump up to get past the current and climb the ladder to reach this area without dayTime or Super Flippers.
 			*/
             return canAccess("E2", inventory)
-                    && (dayOnly || canSuperSwim(inventory)
-			|| (difficulty >= Difficulty.MERCILESS && canSwim(inventory) && inventory.contains(Items.GARLIC)));
+                && (dayOnly || canSuperSwim(inventory)
+			        || (difficulty >= Difficulty.MERCILESS && canSwim(inventory) && inventory.contains(Items.GARLIC)));
         }
         else if (location.equals("E3S")) {
             return canAccess("E3", inventory)
@@ -1982,8 +1984,8 @@ public class Main {
 			* A Glove check has been added specifically for the Key Cards option since that option strictly requires having a Glove.
 			*/ 
             return canAccess("E5", inventory)
-                && (inventory.contains(Items.BLUE_KEY_CARD) && inventory.contains(Items.RED_KEY_CARD) && canLift(inventory))
-			|| (inventory.contains(Items.WARP_REMOTE) && (difficulty >= Difficulty.MERCILESS || canLift(inventory)));
+                && ((inventory.contains(Items.BLUE_KEY_CARD) && inventory.contains(Items.RED_KEY_CARD) && canLift(inventory))
+			        || (inventory.contains(Items.WARP_REMOTE) && (difficulty >= Difficulty.MERCILESS || canLift(inventory))));
         }
         else if (location.equals("E5B")) {
         	/*
@@ -1993,19 +1995,21 @@ public class Main {
 		* The Boots and Golden Glove are both required to perform this execution.
 		*/ 
 		return canAccess("E5", inventory)
-			&& (inventory.contains(Items.BLUE_KEY_CARD) && inventory.contains(Items.RED_KEY_CARD) && canLift(inventory))
-			|| (difficulty >= Difficulty.MERCILESS && inventory.contains(Items.WARP_REMOTE)
-				&& canSuperLift(inventory) && inventory.contains(Items.JUMP_BOOTS));
+			&& ((inventory.contains(Items.BLUE_KEY_CARD) && inventory.contains(Items.RED_KEY_CARD) && canLift(inventory))
+			    || (difficulty >= Difficulty.MERCILESS && inventory.contains(Items.WARP_REMOTE)
+				    && canSuperLift(inventory) && inventory.contains(Items.JUMP_BOOTS)));
         }
         else if (location.equals("E6S")) {
             return canAccess("E6", inventory)
                     && (difficulty >= Difficulty.S_HARD || canLift(inventory));
         }
         else if (location.equals("E6R")) {
+            // can manip pneumo to get past the fire
+			// In addition, you can damage boost using the 2nd Paragoom to get through and reach this chest without needing Overalls.
             return canAccess("E6", inventory)
-                    && inventory.contains(Items.FIRE_EXTINGUISHER)
+                    && (difficulty >= Difficulty.HARD || inventory.contains(Items.FIRE_EXTINGUISHER))
                     && canLift(inventory)
-                    && canGP(inventory);
+                    && (difficulty >= Difficulty.HARD || canGP(inventory));
         }
         else if (location.equals("E6G")) {
             return canAccess("E6", inventory)
@@ -2250,11 +2254,16 @@ public class Main {
 			&& (difficulty > Difficulty.EASY || inventory.contains(Items.JUMP_BOOTS));
             }
             else if (region == 0x15) {
+				// New MINOR GLITCHES Logic for Inside 2nd Hill.
+				// You can skip needing Boots if you have Red Overalls by breaking the blocks in a specific way, and then doing a walljump after obtaining this check.
                 return inventory.contains(Items.GARLIC) && canLift(inventory)
-                        && (canSwim(inventory) || (difficulty >= Difficulty.HARD && inventory.contains(Items.JUMP_BOOTS)));
+                        && (canSwim(inventory) || ((difficulty >= Difficulty.HARD && inventory.contains(Items.JUMP_BOOTS)) || (difficulty >= Difficulty.S_HARD && canSuperGP(inventory)));
             }
             else if (region == 0x16) {
-                return inventory.contains(Items.GARLIC) && (canSwim(inventory) || (difficulty >= Difficulty.S_HARD && inventory.contains(Items.JUMP_BOOTS)));
+				// New MINOR GLITCHES Logic for Inside 4th Hill.
+				// You can skip needing Boots if you have Red Overalls by breaking the blocks in a specific way, and then doing a reverse walljump after obtaining this check.
+                return inventory.contains(Items.GARLIC) 
+						&& (canSwim(inventory) || (difficulty >= Difficulty.S_HARD && (inventory.contains(Items.JUMP_BOOTS) || canSuperGP(inventory))));
             }
             else if (region == 0x17) {
 		/*
@@ -2270,8 +2279,8 @@ public class Main {
 		* The Glove can be skipped by using a High Walljump, when compared to the HARD Logic execution.
 		*/
                 return canSwim(inventory) 
-			|| (difficulty >= Difficulty.HARD && inventory.contains(Items.JUMP_BOOTS)
-				&& (difficulty >= Difficulty.S_HARD || canLift(inventory)));
+			        || (difficulty >= Difficulty.HARD && inventory.contains(Items.JUMP_BOOTS)
+				        && (difficulty >= Difficulty.S_HARD || canLift(inventory)));
             }
         }
         else if (level.equals("N5")) {
@@ -2371,14 +2380,19 @@ public class Main {
         else if (level.equals("W1")) {
             if (region == 0x1) {
                 if (location == 0) {
-                    return !daytime || (inventory.contains(Items.GARLIC) && canSuperGP(inventory));
+					// New MERCILESS Logic for Main Area - By Underground Ladder.
+					// This can be obtained during the day by Ladder Scrolling at the start to screen wrap downwards.
+                    return (!daytime || (daytime && difficulty >= Difficulty.MERCILESS)) || (inventory.contains(Items.GARLIC) && canSuperGP(inventory));
                 }
                 else {
                     if (daytime) {
-                        return inventory.contains(Items.GARLIC) && canSuperGP(inventory);
+						// New MERCILESS Logic for Main Area - Above Underground Quicksand Pool.
+						// This can be obtained during the day by Ladder Scrolling at the start to screen wrap downwards.
+						// It can be reached at night without any powerups in the same manner as well.
+                        return (inventory.contains(Items.GARLIC) && canSuperGP(inventory)) || difficulty >= Difficulty.MERCILESS;
                     }
                     else {
-                        return inventory.contains(Items.GARLIC) || canGP(inventory);
+                        return inventory.contains(Items.GARLIC) || canGP(inventory) || difficulty >= Difficulty.MERCILESS;
                     }
                 }
             }
@@ -2502,10 +2516,10 @@ public class Main {
 			* This is because you would not be able to swim down if it's the Green or Blue Keys in this situation.
 			*/
                     return canGP(inventory)
-			|| (difficulty >= Difficulty.HARD
-				&& ((canSwim(inventory) || (inventory.contains(Items.BEANSTALK_SEEDS)))
-                		&& canLift(inventory)
-                        	&& inventory.contains(Items.JUMP_BOOTS)));
+			            || (difficulty >= Difficulty.HARD
+				            && ((canSwim(inventory) || (inventory.contains(Items.BEANSTALK_SEEDS)))
+                		        && canLift(inventory)
+                        	    && inventory.contains(Items.JUMP_BOOTS)));
                 }
                 else if (location == 2) {
                     return canSwim(inventory);
@@ -2540,8 +2554,8 @@ public class Main {
 		* This execution skips the need for the Air Pump.
 		*/
                 return (inventory.contains(Items.PUMP) && canSwim(inventory))
-			|| (difficulty >= Difficulty.MERCILESS && canGP(inventory) && canLift(inventory) && inventory.contains(Items.JUMP_BOOTS) 
-				&& (canSwim(inventory) || keyColor == 3));
+			        || (difficulty >= Difficulty.MERCILESS && canGP(inventory) && canLift(inventory) && inventory.contains(Items.JUMP_BOOTS)
+				        && (canSwim(inventory) || keyColor == 3));
             }
         }
         else if (level.equals("W4")) {
@@ -2615,7 +2629,7 @@ public class Main {
 		* With a Reverse Walljump, it's possible to obtain this check without either the Helmet or Boots.
 		*/
                 return inventory.contains(Items.SPIKED_HELMET) || inventory.contains(Items.JUMP_BOOTS)
-			|| difficulty >= Difficulty.S_HARD;
+			        || difficulty >= Difficulty.S_HARD;
             }
             else if (region == 0x1c) {
 		/*
@@ -2940,8 +2954,10 @@ public class Main {
 			&& (difficulty >= Difficulty.S_HARD || canLift(inventory));
             }
             else if (region == 0x7) {
+				// New MERCILESS Logic for Main Area - Center Left Ledge.
+				// Using Ladder Scrolling at the start and a walljump, this check can be reached without needing Boots.
                 if (location == 0) {
-                    return inventory.contains(Items.JUMP_BOOTS);
+                    return inventory.contains(Items.JUMP_BOOTS) || difficulty >= Difficulty.MERCILESS;
                 }
                 else {
 		/*
@@ -3258,16 +3274,18 @@ public class Main {
             }
             else if (region == 0x7) {
                 if (location == 0) {
-                    return canLift(inventory) && canGP(inventory) && inventory.contains(Items.FIRE_EXTINGUISHER);
+                    return canLift(inventory) && canGP(inventory)
+                            && (difficulty >= Difficulty.HARD || inventory.contains(Items.FIRE_EXTINGUISHER));
                 }
                 else {
-                    return canLift(inventory) && inventory.contains(Items.FIRE_EXTINGUISHER);
+                    return canLift(inventory)
+                            && (difficulty >= Difficulty.HARD || inventory.contains(Items.FIRE_EXTINGUISHER));
                 }
             }
             else if (region == 0x11) {
 		// MINOR GLITCHES logic added for Smasher Room.
 		// Wallclip to climb over the barriers that you'd need to throw barrels at.
-                return inventory.contains(Items.FIRE_EXTINGUISHER)
+                return (difficulty >= Difficulty.HARD || inventory.contains(Items.FIRE_EXTINGUISHER))
 					&& (canLift(inventory) || difficulty >= Difficulty.S_HARD);
             }
             else if (region == 0x14) {

--- a/src/Main.java
+++ b/src/Main.java
@@ -3182,9 +3182,13 @@ public class Main {
                 return inventory.contains(Items.DETONATOR) && inventory.contains(Items.JUMP_BOOTS);
             }
             else if (region == 0xa) {
+				// To get Red Chest Room - Upper Right without needing the Helmet in MINOR GLITCHES, perform the Rolling Glitch in the previous room.
+				// From there, break the blocks in a specific manner to get enough height to reach the check. A Reverse walljump is required to do this. 
+				// Additionally, a quick directional input change is required to break an additional block to allow you to properly stand in the foothold without being crouched.
                 return inventory.contains(Items.GARLIC)
                         && (inventory.contains(Items.SPIKED_HELMET)
-                            || (difficulty > Difficulty.EASY && inventory.contains(Items.JUMP_BOOTS)));
+                            || (difficulty > Difficulty.EASY && inventory.contains(Items.JUMP_BOOTS))
+							|| difficulty >= Difficulty.S_HARD);
             }
             else if (region == 0x14) {
                 return inventory.contains(Items.GARLIC) && canLift(inventory);

--- a/src/Main.java
+++ b/src/Main.java
@@ -2261,16 +2261,16 @@ public class Main {
             else if (region == 0x15) {
 				// New MINOR GLITCHES Logic for Inside 2nd Hill.
 				// You can skip needing Boots if you have Red Overalls by breaking the blocks in a specific way, and then doing a walljump after obtaining this check.
-				// This can only be in logic on MINOR GLITCHES if it specifically contains the Red Key.
+				// If this check contains the Grey or Blue Keys, you need to break the blocks of the 1st Hill in the same manner to prevent a single-tile walljump.
                 return inventory.contains(Items.GARLIC) && canLift(inventory)
                         && (canSwim(inventory) 
 							|| ((difficulty >= Difficulty.HARD && inventory.contains(Items.JUMP_BOOTS)) 
-							|| (difficulty >= Difficulty.S_HARD && canSuperGP(inventory)));
+							|| (difficulty >= Difficulty.S_HARD && canSuperGP(inventory))));
             }
             else if (region == 0x16) {
 				// New MERCILESS Logic for Inside 4th Hill.
 				// You can skip needing Boots if you have Red Overalls by breaking the blocks in a specific way, and then doing a reverse walljump after obtaining this check.
-				// The required 
+				// The required single-tile walljump takes place at the 3rd hill, which is why this trick is Merciless without Boots.
                 return inventory.contains(Items.GARLIC) 
 						&& (canSwim(inventory) || ((difficulty >= Difficulty.S_HARD && (inventory.contains(Items.JUMP_BOOTS))) || (difficulty >= Difficulty.MERCILESS && canSuperGP(inventory))));
             }
@@ -2522,8 +2522,6 @@ public class Main {
 			* then do a midair enemy bounce using the Paragoom.
 			* If you have Beanstalk Seeds, climb the beanstalk, then immediately fall down.
 			* Then go across the 2nd set of pipes and do the same midair enemy bounce using the Paragoom.
-			* The latter option can only be in logic if this check is specifically the Grey or Red Keys.
-			* This is because you would not be able to swim down if it's the Green or Blue Keys in this situation.
 			*/
                     return canGP(inventory)
 			            || (difficulty >= Difficulty.HARD

--- a/src/Main.java
+++ b/src/Main.java
@@ -1997,7 +1997,7 @@ public class Main {
 		return canAccess("E5", inventory)
 			&& ((inventory.contains(Items.BLUE_KEY_CARD) && inventory.contains(Items.RED_KEY_CARD) && canLift(inventory))
 			    || (difficulty >= Difficulty.MERCILESS && inventory.contains(Items.WARP_REMOTE)
-				    && canSuperLift(inventory) && inventory.contains(Items.JUMP_BOOTS)));
+				    && canSuperGP(inventory) && canSuperLift(inventory) && inventory.contains(Items.JUMP_BOOTS)));
         }
         else if (location.equals("E6S")) {
             return canAccess("E6", inventory)


### PR DESCRIPTION
Added to HARD:
-W5 Blue Chest without a Glove using precise movement to eat the donut while on the ledge containing the Donut Blocks -E6 Red Chest without Overalls using a damage boost to get to the other side containing the first thrown Paragoom

Added to MINOR GLITCHES:
-N4 Inside 2nd Hill with Red Overalls using a walljump to skip needing Boots -N4 Inside 4th Hill with Red Overalls using a reverse walljump without needing Boots

Added to MERCILESS:
-W1 Main Area to reach both checks during the day without needing Garlic or Red Overalls by Ladder Scrolling at the start. Above Underground Quicksand Pool can be reached at night in the same way as well without needing powerups. -S5 Main Area - Center Left Ledge by Ladder Scrolling at the start and a walljump to obtain without needing Boots.