### PR TITLE
Quaking Block Clips Addition to Minor Glitches Logic

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -36,7 +36,7 @@ public class Main {
 
     private static GUI gui;
 
-    private static final String VERSION = "v0.12.0-RC5";
+    private static final String VERSION = "v0.12.0-RC6";
 
     public static void main(String[] args) {
         SwingUtilities.invokeLater(new Runnable() {

--- a/src/Main.java
+++ b/src/Main.java
@@ -36,7 +36,7 @@ public class Main {
 
     private static GUI gui;
 
-    private static final String VERSION = "v0.12.0-RC4";
+    private static final String VERSION = "v0.12.0-RC5";
 
     public static void main(String[] args) {
         SwingUtilities.invokeLater(new Runnable() {
@@ -2406,22 +2406,31 @@ public class Main {
                 }
             }
             else if (region == 0x5) {
+				// New way to access this in MINOR GLITCHES.
+				// If you have Red Overalls, you can perform Quaking Block clips to break the necessary blocks to reach the Night Ruins without needing Garlic.
                 return canSuperGP(inventory)
-                        && ((difficulty > Difficulty.EASY && inventory.contains(Items.JUMP_BOOTS))
-                            || canLift(inventory))
-                        && (!daytime || inventory.contains(Items.GARLIC));
+                    && ((difficulty > Difficulty.EASY && inventory.contains(Items.JUMP_BOOTS))
+                        || canLift(inventory))
+                    && (!daytime || inventory.contains(Items.GARLIC) || difficulty >= Difficulty.S_HARD);
             }
             else if (region == 0x6) {
                 if (location == 0) {
+					// New way to access Night Ruins - Between Upper Pipes in MINOR GLITCHES.
+					// If you have Red Overalls, you can perform Quaking Block clips to break the necessary blocks to reach this check without needing Garlic.
                     return inventory.contains(Items.GARLIC)
-                            || (!daytime && inventory.contains(Items.SPIKED_HELMET) && canGP(inventory));
+                        || (!daytime && inventory.contains(Items.SPIKED_HELMET) && canGP(inventory))
+						|| (difficulty >= Difficulty.S_HARD && canSuperGP(inventory));
                 }
                 else {
-                    return canSuperGP(inventory) && canLift(inventory) && (!daytime || inventory.contains(Items.GARLIC));
+					// New way to access Night Ruins - Behind Lower Left Pipes in MINOR GLITCHES.
+					// If you have Red Overalls, you can perform Quaking Block clips to break the necessary blocks to reach the Night Ruins without needing Garlic.
+                    return canSuperGP(inventory) && canLift(inventory) && (!daytime || inventory.contains(Items.GARLIC) || difficulty >= Difficulty.S_HARD);
                 }
             }
             else if (region == 0x8) {
-                if (!daytime && !inventory.contains(Items.GARLIC)) {
+				// New way to access the Day Ruins in MINOR GLITCHES or above.
+				// If you have Red Overalls, you can perform Quaking Block clips to break the necessary blocks to reach the Day Ruins without needing Garlic.
+                if ((!daytime && !inventory.contains(Items.GARLIC)) || (difficulty < Difficulty.S_HARD && !canSuperGP(inventory))) {
                     return false;
                 }
                 else if (location == 0) {
@@ -2442,10 +2451,12 @@ public class Main {
                 return true;
             }
             else if (region == 0x18) {
+				// New way to access this in MINOR GLITCHES.
+				// If you have Red Overalls, you can perform Quaking Block clips to break the necessary blocks to reach the Night Ruins without needing Garlic.
                 return canSuperGP(inventory)
-                        && (canLift(inventory)
-                            || (difficulty > Difficulty.EASY && inventory.contains(Items.JUMP_BOOTS)))
-                        && (!daytime || inventory.contains(Items.GARLIC));
+                    && (canLift(inventory)
+                        || (difficulty > Difficulty.EASY && inventory.contains(Items.JUMP_BOOTS)))
+                    && (!daytime || inventory.contains(Items.GARLIC) || difficulty >= Difficulty.S_HARD);
             }
         }
         else if (level.equals("W2")) {
@@ -2857,13 +2868,17 @@ public class Main {
             else if (region == 0x19) {
 
                 if (location == 0) { // S2 Spiders Upper Right
+					// New way to access this in MINOR GLITCHES.
+					// If you have Red Overalls, you can perform Quaking Block clips to break the necessary blocks without needing Garlic.
                     return (canSwim(inventory) || (difficulty >= Difficulty.S_HARD && canLift(inventory) && inventory.contains(Items.JUMP_BOOTS)))
-                        && (inventory.contains(Items.GARLIC) || (difficulty >= Difficulty.S_HARD && inventory.contains(Items.JUMP_BOOTS)))
+                        && (inventory.contains(Items.GARLIC) || (difficulty >= Difficulty.S_HARD && (canSuperGP(inventory) || inventory.contains(Items.JUMP_BOOTS))))
 		            && (canSuperGP(inventory) || (difficulty >= Difficulty.HARD && inventory.contains(Items.JUMP_BOOTS)));
                 }
                 else { // S2 Spiders Lower Right
+					// New way to access this in MINOR GLITCHES.
+					// If you have Red Overalls, you can perform Quaking Block clips to break the necessary blocks without needing Garlic.
                     return (canSwim(inventory) || (difficulty >= Difficulty.S_HARD && inventory.contains(Items.JUMP_BOOTS) && canLift(inventory)))
-		            && (inventory.contains(Items.GARLIC) || (difficulty >= Difficulty.S_HARD && inventory.contains(Items.JUMP_BOOTS)));
+		            && (inventory.contains(Items.GARLIC) || (difficulty >= Difficulty.S_HARD && (canSuperGP(inventory) || inventory.contains(Items.JUMP_BOOTS))));
                 }
             }
         }
@@ -3195,7 +3210,10 @@ public class Main {
 							|| difficulty >= Difficulty.S_HARD);
             }
             else if (region == 0x14) {
-                return inventory.contains(Items.GARLIC) && canLift(inventory);
+				// New MINOR GLITCHES Logic for Small Throw Block Room - Lower.
+				// Perform Quaking Block clips to break the solid blocks necessary and gain access to the room without needing Garlic.
+                return canLift(inventory)
+					&& (inventory.contains(Items.GARLIC) || (difficulty >= Difficulty.S_HARD && canSuperGP(inventory)));
             }
             else if (region == 0x1B) {
                 if (location == 1) {
@@ -3331,8 +3349,9 @@ public class Main {
         }
         else if (level.equals("E7")) {
             if (region == 0x1) {
+				// NORMAL Logic for Main Area - Upper Center: it only takes a precise jump to obtain this check if it contains a key, due to a key's bigger hitbox.
                 if (location == 0) {
-                    return inventory.contains(Items.JUMP_BOOTS);
+                    return inventory.contains(Items.JUMP_BOOTS) || difficulty > Difficulty.EASY;
                 }
                 else {
                     return true;

--- a/src/Main.java
+++ b/src/Main.java
@@ -1572,21 +1572,34 @@ public class Main {
                     && inventory.contains(Items.NIGHT_VISION_GOGGLES);
         }
         else if (location.equals("W1S")) {
-            return canAccess("W1", inventory) && (dayOnly || inventory.contains(Items.GARLIC));
+			// New way to access this in MINOR GLITCHES.
+			// If you have Red Overalls, you can perform Quaking Block clips to break the necessary blocks to reach the Day Ruins at night without needing Garlic.
+            return canAccess("W1", inventory) 
+				&& (dayOnly || inventory.contains(Items.GARLIC)
+					|| (difficulty >= Difficulty.S_HARD && canSuperGP(inventory)));
         }
         else if (location.equals("W1R")) {
-            return canAccess("W1", inventory) && (!dayOnly || inventory.contains(Items.GARLIC));
+			// New way to access this in MINOR GLITCHES.
+			// If you have Red Overalls, you can perform Quaking Block clips to break the necessary blocks to reach the Night Ruins during the day without needing Garlic.
+            return canAccess("W1", inventory)
+				&& (!dayOnly || inventory.contains(Items.GARLIC)
+					|| (difficulty >= Difficulty.S_HARD && canSuperGP(inventory)));
         }
         else if (location.equals("W1G")) {
+			// New way to access this in MINOR GLITCHES.
+			// If you have Red Overalls, you can perform Quaking Block clips to break the necessary blocks to reach the Night Ruins during the day without needing Garlic.
             return canAccess("W1", inventory)
-                    && inventory.contains(Items.SPIKED_HELMET)
-                    && (!dayOnly || inventory.contains(Items.GARLIC));
+                && inventory.contains(Items.SPIKED_HELMET)
+                && (!dayOnly || inventory.contains(Items.GARLIC)
+					|| (difficulty >= Difficulty.S_HARD && canSuperGP(inventory)));
         }
         else if (location.equals("W1B")) {
+			// New way to access this in MINOR GLITCHES.
+			// If you have Red Overalls, you can perform Quaking Block clips to break the necessary blocks to reach the Night Ruins during the day without needing Garlic.
             return canAccess("W1", inventory)
                     && canSuperGP(inventory)
                     && (canLift(inventory) || (difficulty > Difficulty.EASY && inventory.contains(Items.JUMP_BOOTS)))
-                    && (!dayOnly || inventory.contains(Items.GARLIC));
+                    && (!dayOnly || inventory.contains(Items.GARLIC) || difficulty >= Difficulty.S_HARD);
         }
         else if (location.equals("W2S")) {
             return canAccess("W2", inventory);


### PR DESCRIPTION
The main additions in this logic is the addition of Quaking Block Clips. This is used to break through solid blocks without Garlic by instead using Red Overalls and wall clipping. Only limited length spaces are considered since you only have so much space to work with using this trick. This is why areas such as N5 Blue's area and E4's Red Chest are not added, whereas smaller length areas like the ones noted are added.

E7 Main Area - Upper Center was added into Normal Logic to obtain without Boots as it was discovered that it can be obtained without Boots as long as it's a Key. This is due to the larger hitbox of a Key when compared to the music coins. Demonstration for this: https://www.youtube.com/watch?v=z0JozyrAp0Q&t=1080s